### PR TITLE
移除对python3.11的支持

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "MoFox-Bot"
 version = "0.12.0"
 description = "MoFox-Bot 是一个基于大语言模型的可交互智能体"
-requires-python = ">=3.11,<=3.13"
+requires-python = ">=3.12,<=3.13"
 dependencies = [
     "aiohttp>=3.12.14",
     "aiohttp-cors>=0.8.1",


### PR DESCRIPTION
移除 pyproject.toml 中所述的对python3.11的支持，理由在 #19 中已经说明。

_看起来是一个微不足道的改动，但我因为这个问题不得不重新安装python以运行MoFox。 T_T _ 

根据 https://docs.python.org/zh-cn/3.12/whatsnew/3.12.html#pep-701-syntactic-formalization-of-f-strings 所述，在f-string中使用其他双引号的功能在python3.12才被引入，而仓库现有代码 src/plugins/built_in/napcat_adapter_plugin/src/recv_handler/notice_handler.py:387 使用了该特性

```
        await event_manager.trigger_event(
                        NapcatEvent.ON_RECEIVED.EMOJI_LIEK, 
                        permission_group=PLUGIN_NAME, 
                        group_id=group_id,
                        user_id=user_id,
                        message_id=raw_message.get("message_id",""),
                        emoji_id=like_emoji_id
                        )     
        **seg_data = Seg(type="text",data=f"{user_name}使用Emoji表情{QQ_FACE.get(like_emoji_id,'')}回复了你的消息[{target_message_text}]")**
        return seg_data, user_info
```
由于不能确认是否有其他地方使用了python3.12的特性，因此建议移除对python3.11的支持，以防止存在隐患。

由于该修改并未引入需要测试的功能，因此合并该PR应当是安全的。 