### PR TITLE
新增request_handler 

### DIFF
--- a/src/plugin_system/utils/dependency_alias.py
+++ b/src/plugin_system/utils/dependency_alias.py
@@ -121,4 +121,6 @@ INSTALL_NAME_TO_IMPORT_NAME = {
     "apache-airflow": "airflow",  # Airflow工作流管理
     "pandas-stubs": "pandas-stubs",  # Pandas的类型存根
     "data-science-types": "data_science_types",  # 数据科学类型
+    # ============== 语音 ==============
+    "openai-whisper": "whisper"  # 用于本地语音转文本功能
 }

--- a/src/plugins/built_in/napcat_adapter/plugin.py
+++ b/src/plugins/built_in/napcat_adapter/plugin.py
@@ -24,6 +24,7 @@ from src.plugin_system.base import BaseAdapter, BasePlugin
 
 from .src.handlers import utils as handler_utils
 from .src.handlers.to_core.message_handler import MessageHandler
+from .src.handlers.to_core.request_handler import RequestHandler
 from .src.handlers.to_core.meta_event_handler import MetaEventHandler
 from .src.handlers.to_core.notice_handler import NoticeHandler
 from .src.handlers.to_napcat.send_handler import SendHandler
@@ -72,6 +73,7 @@ class NapcatAdapter(BaseAdapter):
 
         # 初始化处理器
         self.message_handler = MessageHandler(self)
+        self.request_handler = RequestHandler(self)
         self.notice_handler = NoticeHandler(self)
         self.meta_event_handler = MetaEventHandler(self)
         self.send_handler = SendHandler(self)
@@ -181,6 +183,7 @@ class NapcatAdapter(BaseAdapter):
         # 设置处理器配置
         if self.plugin:
             self.message_handler.set_plugin_config(self.plugin.config)
+            self.request_handler.set_plugin_config(self.plugin.config)
             self.notice_handler.set_plugin_config(self.plugin.config)
             self.meta_event_handler.set_plugin_config(self.plugin.config)
             self.send_handler.set_plugin_config(self.plugin.config)
@@ -247,6 +250,7 @@ class NapcatAdapter(BaseAdapter):
         - message 事件 → 消息
         - notice 事件 → 通知（戳一戳、表情回复等）
         - meta_event 事件 → 元事件（心跳、生命周期）
+        - request 事件 →  请求（群邀请等）
         - API 响应 → 存入响应池
 
         注意：黑白名单等过滤机制在此方法最开始执行，确保所有类型的事件都能被过滤。
@@ -270,6 +274,10 @@ class NapcatAdapter(BaseAdapter):
             # 消息事件
             if post_type == "message":
                 return await self.message_handler.handle_raw_message(raw)  # type: ignore[return-value]
+
+            # 请求事件
+            elif post_type == "request":
+                return await self.request_handler.handle_request(raw)    # type: ignore[return-value]
 
             # 通知事件
             elif post_type == "notice":

--- a/src/plugins/built_in/napcat_adapter/src/event_models.py
+++ b/src/plugins/built_in/napcat_adapter/src/event_models.py
@@ -34,6 +34,7 @@ class NoticeType:  # 通知事件
     group_ban = "group_ban"  # 群禁言
     group_msg_emoji_like = "group_msg_emoji_like"  # 群聊表情回复
     group_upload = "group_upload"  # 群文件上传
+    group_increase = "group_increase"  # 群成员增加
 
     class Notify:
         poke = "poke"  # 戳一戳

--- a/src/plugins/built_in/napcat_adapter/src/handlers/to_core/notice_handler.py
+++ b/src/plugins/built_in/napcat_adapter/src/handlers/to_core/notice_handler.py
@@ -65,6 +65,21 @@ class NoticeHandler:
         }
 
         match notice_type:
+            case NoticeType.group_increase:
+                logger.info("群员增加消息")
+                sub_type = raw.get("sub_type")
+                user_id = raw.get("user_id")
+                fetched_member = await get_member_info(group_id=group_id, user_id=user_id) if group_id and user_id else None
+                nickname = fetched_member.get("nickname") if fetched_member else str(user_id)
+                handled_segment = {"type": "text", "data": f"[群成员变动] {nickname} 加入了群 ({sub_type})"}
+                user_info = {
+                    "user_id": str(user_id or ""),
+                    "user_nickname": nickname or "",
+                    "user_cardname": "",
+                }
+                notice_config["notice_type"] = "group_increase"
+                notice_config["is_notice"] = True
+                return None
             case NoticeType.friend_recall:
                 logger.info("好友撤回一条消息")
                 logger.info(f"撤回消息ID：{raw.get('message_id')}, 撤回时间：{raw.get('time')}")

--- a/src/plugins/built_in/napcat_adapter/src/handlers/to_core/notice_handler.py
+++ b/src/plugins/built_in/napcat_adapter/src/handlers/to_core/notice_handler.py
@@ -65,21 +65,6 @@ class NoticeHandler:
         }
 
         match notice_type:
-            case NoticeType.group_increase:
-                logger.info("群员增加消息")
-                sub_type = raw.get("sub_type")
-                user_id = raw.get("user_id")
-                fetched_member = await get_member_info(group_id=group_id, user_id=user_id) if group_id and user_id else None
-                nickname = fetched_member.get("nickname") if fetched_member else str(user_id)
-                handled_segment = {"type": "text", "data": f"[群成员变动] {nickname} 加入了群 ({sub_type})"}
-                user_info = {
-                    "user_id": str(user_id or ""),
-                    "user_nickname": nickname or "",
-                    "user_cardname": "",
-                }
-                notice_config["notice_type"] = "group_increase"
-                notice_config["is_notice"] = True
-                return None
             case NoticeType.friend_recall:
                 logger.info("好友撤回一条消息")
                 logger.info(f"撤回消息ID：{raw.get('message_id')}, 撤回时间：{raw.get('time')}")

--- a/src/plugins/built_in/napcat_adapter/src/handlers/to_core/request_handler.py
+++ b/src/plugins/built_in/napcat_adapter/src/handlers/to_core/request_handler.py
@@ -61,6 +61,24 @@ class RequestHandler:
         flag = raw.get("flag")
         comment = raw.get("comment", "")
 
+        # 使用平台事件时间，如果不可用则回退到当前时间
+        raw_time = raw.get("time")
+        event_ts_seconds: float | None
+        try:
+            if raw_time is None:
+                event_ts_seconds = None
+            else:
+                # OneBot 平台一般使用秒时间戳，这里统一转换为 float
+                event_ts_seconds = float(raw_time)
+        except (TypeError, ValueError):
+            event_ts_seconds = None
+
+        if event_ts_seconds is None or event_ts_seconds <= 0:
+            # 无效或缺失时回退到当前时间
+            event_ts_seconds = time.time()
+
+        timestamp_ms = int(event_ts_seconds * 1000)
+
         if not request_type:
             logger.warning("缺少 request_type，跳过处理")
             return None
@@ -72,8 +90,8 @@ class RequestHandler:
 
         (
             mb.direction("incoming")
-            .message_id(str(flag or f"request:{int(time.time())}"))
-            .timestamp_ms(int(time.time() * 1000))
+            .message_id(str(flag or f"request:{timestamp_ms}"))
+            .timestamp_ms(timestamp_ms)
             .from_user(user_id=user_id, platform="qq")
         )
 
@@ -106,6 +124,8 @@ class RequestHandler:
                 "request_detail": {
                     "request_type": request_type,
                     "sub_type": sub_type,
+                    "user_id": user_id,
+                    "group_id": group_id,
                     "flag": flag,
                     "comment": comment,
                 },

--- a/src/plugins/built_in/napcat_adapter/src/handlers/to_core/request_handler.py
+++ b/src/plugins/built_in/napcat_adapter/src/handlers/to_core/request_handler.py
@@ -54,8 +54,8 @@ class RequestHandler:
         }
         """
 
-        request_type = raw.get("request_type")
-        sub_type = str(raw.get("sub_type", ""))
+        request_type = str(raw.get("request_type", "") or "")
+        sub_type = str(raw.get("sub_type", "") or "")
         user_id = str(raw.get("user_id", ""))
         group_id = raw.get("group_id")
         flag = raw.get("flag")
@@ -79,8 +79,8 @@ class RequestHandler:
 
         timestamp_ms = int(event_ts_seconds * 1000)
 
-        if not request_type:
-            logger.warning("缺少 request_type，跳过处理")
+        if request_type not in {"group", "friend"}:
+            logger.warning(f"不支持的 request_type: {request_type}")
             return None
 
         # 适配器层不再自动同意，由插件 auto_accept_requests 统一处理
@@ -92,20 +92,23 @@ class RequestHandler:
             mb.direction("incoming")
             .message_id(str(flag or f"request:{timestamp_ms}"))
             .timestamp_ms(timestamp_ms)
-            .from_user(user_id=user_id, platform="qq")
+            .from_user(user_id=user_id, platform=self.adapter.platform)
         )
 
         # 群信息（仅群请求）
         if request_type == "group" and group_id:
-            mb.from_group(group_id=str(group_id), platform="qq")
+            mb.from_group(group_id=str(group_id), platform=self.adapter.platform)
 
         # 片段占位，统一为文本提示
         if request_type == "group":
             text = f"收到群邀请请求，来自 {user_id}，群 {group_id}"
             content_format = ["text", "notify"]
-        else:
+        elif request_type == "friend":
             text = f"收到好友添加请求，来自 {user_id}"
             content_format = ["text", "notify"]
+        else:
+            logger.warning(f"不支持的 request_type: {request_type}")
+            return None
 
         mb.format_info(content_format=content_format, accept_format=ACCEPT_FORMAT)
         mb.seg_list([{"type": "text", "data": text}])

--- a/src/plugins/built_in/napcat_adapter/src/handlers/to_core/request_handler.py
+++ b/src/plugins/built_in/napcat_adapter/src/handlers/to_core/request_handler.py
@@ -1,0 +1,115 @@
+"""请求事件处理器 - 处理 Napcat OneBot 的 request 事件
+
+支持：
+- 好友请求（request_type=friend）
+- 群请求（request_type=group，sub_type=invite/add）
+
+职责：
+- 仅进行 OneBot → MessageEnvelope 封装，并附加 request 详情到 additional_config
+- 审批与通知由插件系统（如 auto_accept_requests）通过 ON_NOTICE_RECEIVED 执行
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import time
+from mofox_wire import MessageBuilder
+
+from src.common.logger import get_logger
+from ...event_models import ACCEPT_FORMAT
+
+if TYPE_CHECKING:
+    from ....plugin import NapcatAdapter
+
+
+logger = get_logger("napcat_adapter")
+
+
+class RequestHandler:
+    """处理 Napcat 的 request 事件"""
+
+    def __init__(self, adapter: "NapcatAdapter"):
+        self.adapter = adapter
+        self.plugin_config: dict[str, Any] | None = None
+
+    def set_plugin_config(self, config: dict[str, Any]) -> None:
+        """设置插件配置"""
+        self.plugin_config = config
+
+    async def handle_request(self, raw: dict[str, Any]) -> dict | None:
+        """处理 request 事件并返回 MessageEnvelope
+
+        事件示例（OneBot 11/Napcat）：
+        {
+            "post_type": "request",
+            "request_type": "group" | "friend",
+            "sub_type": "invite" | "add",
+            "group_id": 111,
+            "user_id": 1111,
+            "comment": "",
+            "flag": "111213",
+            "self_id": 123,
+            "time": 23123
+        }
+        """
+
+        request_type = raw.get("request_type")
+        sub_type = str(raw.get("sub_type", ""))
+        user_id = str(raw.get("user_id", ""))
+        group_id = raw.get("group_id")
+        flag = raw.get("flag")
+        comment = raw.get("comment", "")
+
+        if not request_type:
+            logger.warning("缺少 request_type，跳过处理")
+            return None
+
+        # 适配器层不再自动同意，由插件 auto_accept_requests 统一处理
+
+        # 构造 MessageEnvelope，作为 Notice 类型进入核心流程
+        mb = MessageBuilder()
+
+        (
+            mb.direction("incoming")
+            .message_id(str(flag or f"request:{int(time.time())}"))
+            .timestamp_ms(int(time.time() * 1000))
+            .from_user(user_id=user_id, platform="qq")
+        )
+
+        # 群信息（仅群请求）
+        if request_type == "group" and group_id:
+            mb.from_group(group_id=str(group_id), platform="qq")
+
+        # 片段占位，统一为文本提示
+        if request_type == "group":
+            text = f"收到群邀请请求，来自 {user_id}，群 {group_id}"
+            content_format = ["text", "notify"]
+        else:
+            text = f"收到好友添加请求，来自 {user_id}"
+            content_format = ["text", "notify"]
+
+        mb.format_info(content_format=content_format, accept_format=ACCEPT_FORMAT)
+        mb.seg_list([{"type": "text", "data": text}])
+
+        envelope = mb.build()
+
+        # 附加配置，标记为 notice，供 MessageRuntime 的 notice 路由处理
+        notice_type = "group_invite" if request_type == "group" else "friend_request"
+        envelope.setdefault("message_info", {})
+        envelope["message_info"].setdefault("additional_config", {})
+        envelope["message_info"]["additional_config"].update(
+            {
+                "is_notice": True,
+                "is_public_notice": False,
+                "notice_type": notice_type,
+                "request_detail": {
+                    "request_type": request_type,
+                    "sub_type": sub_type,
+                    "flag": flag,
+                    "comment": comment,
+                },
+            }
+        )
+
+        return envelope


### PR DESCRIPTION
## Summary by Sourcery

Add support in the Napcat adapter for handling OneBot request events and routing them into the core as notice-type message envelopes.

New Features:
- Introduce a RequestHandler to convert OneBot/Napcat friend and group request events into MessageEnvelope notices with attached request metadata.
- Wire the new RequestHandler into the Napcat adapter so request-type post events are processed alongside message, notice, and meta_event types.

Enhancements:
- Extend NoticeType definitions with a group_increase event type for group member join notifications.
- Update dependency alias mapping to include the openai-whisper package for local speech-to-text functionality.