### PR TITLE
Classical

### DIFF
--- a/src/plugins/built_in/maizone_refactored/plugin.py
+++ b/src/plugins/built_in/maizone_refactored/plugin.py
@@ -99,6 +99,24 @@ class MaiZoneRefactoredPlugin(BasePlugin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        async def _refresh_cookies(self, cookie_service):
+        """刷新Cookie的公共方法"""
+        if hasattr(cookie_service, "refresh_cookies"):
+            try:
+                await cookie_service.refresh_cookies(None)
+            except Exception:
+                logger.exception("执行Cookie刷新时发生异常。")
+        else:
+            for p in cookie_service.cookie_dir.glob("cookies-*.json"):
+                name = p.name
+                if name.startswith("cookies-") and name.endswith(".json"):
+                    acc = name[len("cookies-"):-len(".json")]
+                    try:
+                        await cookie_service.get_cookies(acc, None)
+                    except Exception:
+                        logger.exception(f"为 {acc} 执行Cookie刷新时出错")
+
+
     async def on_plugin_loaded(self):
         """插件加载完成后的回调，初始化服务并启动后台任务"""
         # --- 创建并注册所有服务实例 ---

--- a/src/plugins/built_in/maizone_refactored/plugin.py
+++ b/src/plugins/built_in/maizone_refactored/plugin.py
@@ -99,7 +99,7 @@ class MaiZoneRefactoredPlugin(BasePlugin):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        async def _refresh_cookies(self, cookie_service):
+    async def _refresh_cookies(self, cookie_service):
         """刷新Cookie的公共方法"""
         if hasattr(cookie_service, "refresh_cookies"):
             try:

--- a/src/plugins/built_in/maizone_refactored/services/cookie_service.py
+++ b/src/plugins/built_in/maizone_refactored/services/cookie_service.py
@@ -1,10 +1,10 @@
 """
-Cookie服务模块
-负责从多种来源获取、缓存和管理QZone的Cookie。
+Cookie服务模块（不使用本地缓存，每次都重新获取）
 """
 
 from collections.abc import Callable
 from pathlib import Path
+from time import time
 
 import aiohttp
 import orjson
@@ -17,7 +17,7 @@ logger = get_logger("MaiZone.CookieService")
 
 class CookieService:
     """
-    管理Cookie的获取和缓存，支持多种获取策略。
+    管理Cookie的获取（不使用本地缓存，每次都从HTTP或Adapter获取）。
     """
 
     def __init__(self, get_config: Callable):
@@ -26,32 +26,9 @@ class CookieService:
         self.cookie_dir.mkdir(exist_ok=True)
 
     def _get_cookie_file_path(self, qq_account: str) -> Path:
-        """获取指定QQ账号的cookie文件路径"""
         return self.cookie_dir / f"cookies-{qq_account}.json"
 
-    def _save_cookies_to_file(self, qq_account: str, cookies: dict[str, str]):
-        """将Cookie保存到本地文件"""
-        cookie_file_path = self._get_cookie_file_path(qq_account)
-        try:
-            with open(cookie_file_path, "w", encoding="utf-8") as f:
-                f.write(orjson.dumps(cookies, option=orjson.OPT_INDENT_2).decode("utf-8"))
-            logger.info(f"Cookie已成功缓存至: {cookie_file_path}")
-        except OSError as e:
-            logger.error(f"无法写入Cookie文件 {cookie_file_path}: {e}")
-
-    def _load_cookies_from_file(self, qq_account: str) -> dict[str, str] | None:
-        """从本地文件加载Cookie"""
-        cookie_file_path = self._get_cookie_file_path(qq_account)
-        if cookie_file_path.exists():
-            try:
-                with open(cookie_file_path, encoding="utf-8") as f:
-                    return orjson.loads(f.read())
-            except (OSError, orjson.JSONDecodeError) as e:
-                logger.error(f"无法读取或解析Cookie文件 {cookie_file_path}: {e}")
-        return None
-
     async def _get_cookies_from_adapter(self, stream_id: str | None) -> dict[str, str] | None:
-        """通过Adapter API获取Cookie"""
         try:
             params = {"domain": "user.qzone.qq.com"}
             if stream_id:
@@ -74,7 +51,6 @@ class CookieService:
         return None
 
     async def _get_cookies_from_http(self) -> dict[str, str] | None:
-        """通过备用HTTP端点获取Cookie（带Token认证）"""
         host = self.get_config("cookie.http_fallback_host", "")
         port = self.get_config("cookie.http_fallback_port", "")
         napcat_token = self.get_config("cookie.napcat_token", "")
@@ -89,7 +65,6 @@ class CookieService:
             timeout = aiohttp.ClientTimeout(total=15)
             payload = {"domain": "user.qzone.qq.com"}
 
-            # 构建请求头，包含Token认证
             headers = {"Content-Type": "application/json"}
             if napcat_token:
                 headers["Authorization"] = f"Bearer {napcat_token}"
@@ -102,8 +77,6 @@ class CookieService:
 
                     response.raise_for_status()
                     data = await response.json()
-
-                    # 确保返回的数据格式被正确解析，兼容Adapter的返回结构
                     cookie_str = data.get("data", {}).get("cookies")
                     if cookie_str and isinstance(cookie_str, str):
                         logger.info("从HTTP备用地址成功获取Cookie。")
@@ -122,35 +95,63 @@ class CookieService:
 
     async def get_cookies(self, qq_account: str, stream_id: str | None) -> dict[str, str] | None:
         """
-        获取Cookie，按以下顺序尝试：
-        1. 本地文件缓存（优先，避免不必要的网络请求）
-        2. HTTP备用端点
-        3. Adapter API（最可靠，作为最后手段）
+        不使用本地缓存：每次优先尝试 HTTP 备用端点，失败则调用 Adapter。
         """
-        # 1. 优先尝试从本地文件加载（最快）
-        cookies = self._load_cookies_from_file(qq_account)
-        if cookies:
-            logger.info("从本地缓存加载Cookie成功。")
-            return cookies
-
-        # 2. 尝试从HTTP备用端点获取
-        logger.info("本地缓存不存在，尝试HTTP备用地址...")
+        logger.info("始终从网络获取Cookie：尝试HTTP备用地址...")
         cookies = await self._get_cookies_from_http()
         if cookies:
             logger.info("从HTTP备用地址获取Cookie成功。")
-            self._save_cookies_to_file(qq_account, cookies)
             return cookies
 
-        # 3. 尝试从Adapter获取（最可靠的方式）
         logger.info("HTTP方式失败，尝试Adapter API...")
         cookies = await self._get_cookies_from_adapter(stream_id)
         if cookies:
             logger.info("从Adapter API获取Cookie成功。")
-            self._save_cookies_to_file(qq_account, cookies)
             return cookies
 
-        logger.error(
-            f"为 {qq_account} 获取Cookie的所有方法均失败。"
-            f"请确保Adapter连接正常，或配置HTTP备用地址，或存在有效的本地Cookie缓存。"
-        )
+        logger.error(f"为 {qq_account} 获取Cookie的所有方法均失败。")
         return None
+
+    async def refresh_cookies(self, qq_account: str | None = None) -> dict | None:
+        """
+        强制刷新指定账号或所有账号的Cookie（不保存到本地）。
+        返回单账号时为 dict 或 None；多账号返回 {account: dict|None}。
+        """
+        results: dict[str, dict | None] = {}
+
+        accounts: list[str] = []
+        if qq_account:
+            accounts = [qq_account]
+        else:
+            cfg_accounts = self.get_config("cookie.auto_refresh_accounts", [])
+            if isinstance(cfg_accounts, (list, tuple)) and cfg_accounts:
+                accounts = [str(a) for a in cfg_accounts]
+            else:
+                for p in self.cookie_dir.glob("cookies-*.json"):
+                    name = p.name
+                    if name.startswith("cookies-") and name.endswith(".json"):
+                        accounts.append(name[len("cookies-"):-len(".json")])
+
+        if not accounts:
+            logger.info("没有找到需要自动刷新的Cookie账号。")
+            return {} if qq_account is None else None
+
+        for acc in accounts:
+            try:
+                logger.info(f"开始强制刷新Cookie: {acc}")
+                cookies = await self._get_cookies_from_http()
+                if not cookies:
+                    cookies = await self._get_cookies_from_adapter(None)
+                if cookies:
+                    logger.info(f"为 {acc} 刷新Cookie成功（未缓存）。")
+                    results[acc] = cookies
+                else:
+                    logger.warning(f"为 {acc} 刷新Cookie失败。")
+                    results[acc] = None
+            except Exception as e:
+                logger.exception(f"刷新 {acc} Cookie 时出现异常: {e}")
+                results[acc] = None
+
+        if qq_account:
+            return results.get(qq_account)
+        return results


### PR DESCRIPTION
修改麦麦空间饼干获取方式，
保留了refresh_cookies方法但不调用，
选择每次发送说说动作重新获取饼干，即不再获取本地缓存，
删除了文件读写相关的代码_save_cookies_to_file等，
网络获取逻辑不变
（猞猁可爱捏）

## Summary by Sourcery

Always retrieve MaiZone cookies from network sources instead of using local file caching, and add a unified cookie refresh helper in the plugin.

Enhancements:
- Disable local file-based cookie caching so cookies are fetched each time via HTTP fallback or Adapter.
- Introduce a refresh_cookies API on CookieService that refreshes cookies in memory without persisting them.
- Add a shared _refresh_cookies helper in the plugin to trigger cookie refresh using the new service API or a legacy fallback approach.