### PR TITLE
fix(template): 更新模型标识符

### DIFF
--- a/template/model_config_template.toml
+++ b/template/model_config_template.toml
@@ -68,7 +68,7 @@ price_out = 8.0                    # 输出价格（用于API调用统计，单�
 #enable_semantic_variants = false # [可选] 启用语义变体。作为一种扰动策略，生成语义上相似但表达不同的提示。默认为 false。
 
 [[models]]
-model_identifier = "deepseek-ai/DeepSeek-V3."
+model_identifier = "deepseek-ai/DeepSeek-V3.2"
 name = "siliconflow-deepseek-ai/DeepSeek-V3.2"
 api_provider = "SiliconFlow"
 price_in = 2.0


### PR DESCRIPTION
**Fix:** `DeepSeek-V3.` → `DeepSeek-V3.2` in `template/model_config_template.toml:71`

## Summary by Sourcery

Bug Fixes:
- Correct the DeepSeek V3 model identifier in the model configuration template to use the V3.2 variant.